### PR TITLE
feat(TextMotion): add split & presets props

### DIFF
--- a/src/TextMotion/TextMotion.scss
+++ b/src/TextMotion/TextMotion.scss
@@ -1,4 +1,4 @@
-@keyframes fade {
+@keyframes fadeIn {
   from {
     opacity: 0;
   }
@@ -7,8 +7,35 @@
   }
 }
 
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(0.4rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-0.4rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
 .text-motion span {
   display: inline-block;
   white-space: pre;
-  animation: fade var(--duration) ease-out var(--delay) both;
+  animation: var(--animation) var(--duration) ease-out var(--delay) both;
 }

--- a/src/TextMotion/TextMotion.tsx
+++ b/src/TextMotion/TextMotion.tsx
@@ -2,16 +2,25 @@ import './TextMotion.scss';
 
 import React, { useMemo } from 'react';
 
-export type SplitType = 'character' | 'word';
+type PresetType = 'fadeIn' | 'fadeOut' | 'slideUp' | 'slideDown';
+type SplitType = 'character' | 'word';
 
 type TextMotionProps = {
   as?: keyof React.JSX.IntrinsicElements;
   text: string;
+  presets?: PresetType[];
   split?: SplitType;
 };
 
 const DEFAULT_DURATION = 0.25;
 const DEFAULT_DELAY = 0.025;
+
+const generateAnimationByPresets = (presets: PresetType[], index: number): React.CSSProperties => {
+  const formattedDelay = parseFloat((index * DEFAULT_DELAY).toFixed(3));
+  const animation = presets.map(preset => `${preset} ${DEFAULT_DURATION}s ease-out ${formattedDelay}s both`).join(', ');
+
+  return { animation };
+};
 
 export const splitText = (text: string, split: SplitType): string[] => {
   if (split === 'character') return text.split('');
@@ -19,23 +28,14 @@ export const splitText = (text: string, split: SplitType): string[] => {
   return text.split('');
 };
 
-export const TextMotion: React.FC<TextMotionProps> = ({ as = 'span', text, split = 'character' }) => {
+export const TextMotion = ({ as = 'span', text, presets = ['fadeIn'], split = 'character' }: TextMotionProps) => {
   const Tag = as;
   const letters = useMemo(() => splitText(text, split), [text, split]);
 
   return (
     <Tag className="text-motion" aria-label={text}>
       {letters.map((letter, index) => (
-        <span
-          key={`${letter}-${index}`}
-          style={
-            {
-              '--duration': `${DEFAULT_DURATION}s`,
-              '--delay': `${index * DEFAULT_DELAY}s`,
-            } as React.CSSProperties
-          }
-          aria-hidden="true"
-        >
+        <span key={`${letter}-${index}`} style={generateAnimationByPresets(presets, index)} aria-hidden="true">
           {letter === ' ' ? '\u00A0' : letter}
         </span>
       ))}


### PR DESCRIPTION
## Description

This PR introduces `split` and `presets` props to the `TextMotion` component.

- `split`: Controls the unit by which the text is divided (`character` or `word`)
- `presets`: Accepts a list of animation presets (`fadeIn`, `fadeOut`, `slideUp`, `slideDown`) and applies them with staggered timing

The component dynamically calculates and applies CSS `animation` styles per unit using these props.

## Related Issue

Closes #5 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the project style guidelines
- [x] I performed a self-review of my own code
- [x] I added tests that prove my fix is effective
- [ ] I added necessary documentation
