### PR TITLE
feat: add `repeat` prop to TextMotion & NodeMotion components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-textmotion · [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE) <!-- > [![npm version](https://img.shields.io/npm/v/react-textmotion.svg)](https://www.npmjs.com/package/react-textmotion) [![Bundle Size](https://img.shields.io/bundlephobia/minzip/react-textmotion)](https://bundlephobia.com/package/react-textmotion) --> [![codecov](https://codecov.io/gh/shubug1015/react-textmotion/graph/badge.svg?token=S6CPN2KSCX)](https://codecov.io/gh/shubug1015/react-textmotion)
+# react-textmotion · [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE) [![codecov](https://codecov.io/gh/shubug1015/react-textmotion/graph/badge.svg?token=S6CPN2KSCX)](https://codecov.io/gh/shubug1015/react-textmotion) [![npm version](https://img.shields.io/npm/v/react-textmotion.svg)](https://www.npmjs.com/package/react-textmotion) <!-- > [![Bundle Size](https://img.shields.io/bundlephobia/minzip/react-textmotion)](https://bundlephobia.com/package/react-textmotion) -->
 
 > 🚀 Animate text and UI elements effortlessly in React.
 > Lightweight, fully tested, and production-ready.
@@ -88,6 +88,7 @@ Animate **any React children** (mixed tags, custom components, blocks).
 <NodeMotion
   split="character"
   trigger="scroll"
+  repeat={false}
   motion={{
     fade: {
       variant: 'in',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-textmotion",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A reusable React component for text animations with customizable motion presets and character/word splitting.",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-textmotion",
   "version": "0.0.2",
-  "description": "A reusable React component for text animations with customizable motion presets and character/word splitting.",
+  "description": "Lightweight yet powerful library that provides variable animation effects for React applications.",
   "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -16,6 +16,7 @@ import { handleValidation, validateNodeMotionProps } from '../../utils';
  * @param {ReactNode} children - The content to animate. Can be a string, a number, or any React element.
  * @param {SplitType} [split='character'] - Defines how the text is split for animation (`character` or `word`). Defaults to `'character'`.
  * @param {'on-load' | 'scroll'} [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
+ * @param {boolean} [repeat] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -36,15 +36,7 @@ import { handleValidation, validateNodeMotionProps } from '../../utils';
  * }
  */
 export const NodeMotion: FC<NodeMotionProps> = memo(props => {
-  const {
-    as: Tag = 'span',
-    children,
-    split = 'character',
-    trigger = 'scroll',
-    motion,
-    preset,
-    repeat = trigger === 'scroll',
-  } = props;
+  const { as: Tag = 'span', children, split = 'character', trigger = 'scroll', motion, preset, repeat = true } = props;
 
   const { errors, warnings } = validateNodeMotionProps(props);
   handleValidation(errors, warnings);

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -49,7 +49,7 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
   const { errors, warnings } = validateNodeMotionProps(props);
   handleValidation(errors, warnings);
 
-  const [targetRef, isIntersecting] = useIntersectionObserver<HTMLSpanElement>();
+  const [targetRef, isIntersecting] = useIntersectionObserver<HTMLSpanElement>({ repeat });
   const shouldAnimate = trigger === 'on-load' || isIntersecting;
 
   const accessibleText = useTextFromReactNode(children);

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -36,7 +36,15 @@ import { handleValidation, validateNodeMotionProps } from '../../utils';
  * }
  */
 export const NodeMotion: FC<NodeMotionProps> = memo(props => {
-  const { as: Tag = 'span', children, split = 'character', trigger = 'scroll', motion, preset } = props;
+  const {
+    as: Tag = 'span',
+    children,
+    split = 'character',
+    trigger = 'scroll',
+    motion,
+    preset,
+    repeat = trigger === 'scroll',
+  } = props;
 
   const { errors, warnings } = validateNodeMotionProps(props);
   handleValidation(errors, warnings);

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -16,7 +16,7 @@ import { handleValidation, validateNodeMotionProps } from '../../utils';
  * @param {ReactNode} children - The content to animate. Can be a string, a number, or any React element.
  * @param {SplitType} [split='character'] - Defines how the text is split for animation (`character` or `word`). Defaults to `'character'`.
  * @param {'on-load' | 'scroll'} [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
- * @param {boolean} [repeat] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
+ * @param {boolean} [repeat=true] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -14,7 +14,7 @@ import { createAnimatedSpan, handleValidation, splitText, validateTextMotionProp
  * @param {string} text - The text content to animate.
  * @param {SplitType} [split='character'] - Defines how the text is split for animation (`character`, `word`, or `line`). Defaults to `'character'`.
  * @param {'on-load' | 'scroll' } [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
- * @param {boolean} [repeat] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
+ * @param {boolean} [repeat=true] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -46,7 +46,7 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
   const { errors, warnings } = validateTextMotionProps(props);
   handleValidation(errors, warnings);
 
-  const [targetRef, isIntersecting] = useIntersectionObserver<HTMLSpanElement>();
+  const [targetRef, isIntersecting] = useIntersectionObserver<HTMLSpanElement>({ repeat });
   const shouldAnimate = trigger === 'on-load' || isIntersecting;
 
   const resolvedMotion = useResolvedMotion(motion, preset);

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -14,6 +14,7 @@ import { createAnimatedSpan, handleValidation, splitText, validateTextMotionProp
  * @param {string} text - The text content to animate.
  * @param {SplitType} [split='character'] - Defines how the text is split for animation (`character`, `word`, or `line`). Defaults to `'character'`.
  * @param {'on-load' | 'scroll' } [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
+ * @param {boolean} [repeat] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -33,15 +33,7 @@ import { createAnimatedSpan, handleValidation, splitText, validateTextMotionProp
  */
 
 export const TextMotion: FC<TextMotionProps> = memo(props => {
-  const {
-    as: Tag = 'span',
-    text,
-    split = 'character',
-    trigger = 'scroll',
-    motion,
-    preset,
-    repeat = trigger === 'scroll',
-  } = props;
+  const { as: Tag = 'span', text, split = 'character', trigger = 'scroll', motion, preset, repeat = true } = props;
 
   const { errors, warnings } = validateTextMotionProps(props);
   handleValidation(errors, warnings);

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -33,7 +33,15 @@ import { createAnimatedSpan, handleValidation, splitText, validateTextMotionProp
  */
 
 export const TextMotion: FC<TextMotionProps> = memo(props => {
-  const { as: Tag = 'span', text, split = 'character', trigger = 'scroll', motion, preset } = props;
+  const {
+    as: Tag = 'span',
+    text,
+    split = 'character',
+    trigger = 'scroll',
+    motion,
+    preset,
+    repeat = trigger === 'scroll',
+  } = props;
 
   const { errors, warnings } = validateTextMotionProps(props);
   handleValidation(errors, warnings);

--- a/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
+++ b/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
@@ -111,33 +111,30 @@ describe('useIntersectionObserver', () => {
     expect(intersected).toBe(true);
   });
 
-  it('should unobserve the element when triggerOnce is true and it intersects', () => {
+  it('should unobserve and not toggle back when repeat is false', () => {
     let intersected = false;
 
     act(() => {
-      render(<TestComponent options={{ triggerOnce: true }} onIntersect={val => (intersected = val)} />);
+      render(<TestComponent options={{ repeat: false }} onIntersect={val => (intersected = val)} />);
     });
 
     const targetElement = screen.getByTestId('target-element');
-
     const observerInstance = mockIntersectionObserver.mock.results[0].value;
     const unobserveSpy = jest.spyOn(observerInstance, 'unobserve');
 
     observerInstance.trigger([{ isIntersecting: true, target: targetElement }]);
-
     expect(intersected).toBe(true);
     expect(unobserveSpy).toHaveBeenCalledWith(targetElement);
 
-    intersected = false;
-    observerInstance.trigger([{ isIntersecting: true, target: targetElement }]);
-    expect(intersected).toBe(false);
+    observerInstance.trigger([{ isIntersecting: false, target: targetElement }]);
+    expect(intersected).toBe(true);
   });
 
-  it('should toggle isIntersecting when triggerOnce is false', () => {
+  it('should toggle isIntersecting when repeat is true', () => {
     let intersected = false;
 
     act(() => {
-      render(<TestComponent options={{ triggerOnce: false }} onIntersect={val => (intersected = val)} />);
+      render(<TestComponent options={{ repeat: true }} onIntersect={val => (intersected = val)} />);
     });
 
     const targetElement = screen.getByTestId('target-element');
@@ -174,7 +171,7 @@ describe('useIntersectionObserver', () => {
     const options = {
       threshold: 0.5,
       rootMargin: '10px',
-      triggerOnce: false,
+      repeat: true,
     };
 
     act(() => {

--- a/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
@@ -9,7 +9,7 @@
  * @param {number} [options.threshold=0] - A single number or an array of numbers indicating at what percentage of the target's visibility the observer's callback should be executed.
  * @param {Element | Document | null} [options.root=null] - The element that is used as the viewport for checking intersection. Defaults to the browser viewport if not specified or if null.
  * @param {string} [options.rootMargin='0%'] - Margin around the root. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left).
- * @param {boolean} [options.triggerOnce=true] - If true, the observer will unobserve the element after the first intersection.
+ * @param {boolean} [options.repeat=false] - If true, the observer will keep observing the element. If false, the observer will unobserve after the first intersection. Defaults to false.
  *
  * @returns {[RefObject<T | null>, boolean]} A tuple containing:
  * - `ref`: A RefObject to be attached to the DOM element you want to observe.
@@ -18,13 +18,13 @@
 import { RefObject, useEffect, useRef, useState } from 'react';
 
 type IntersectionObserverOptions = {
-  triggerOnce?: boolean;
+  repeat?: boolean;
 } & IntersectionObserverInit;
 
 export const useIntersectionObserver = <T extends Element>(
   options: IntersectionObserverOptions = {}
 ): [RefObject<T | null>, boolean] => {
-  const { threshold = 0, root = null, rootMargin = '0%', triggerOnce = true } = options;
+  const { threshold = 0, root = null, rootMargin = '0%', repeat = false } = options;
   const ref = useRef<T>(null);
   const [isIntersecting, setIsIntersecting] = useState(false);
 
@@ -40,11 +40,11 @@ export const useIntersectionObserver = <T extends Element>(
         if (entry.isIntersecting) {
           setIsIntersecting(true);
 
-          if (triggerOnce) {
+          if (!repeat) {
             observer.unobserve(element);
           }
         } else {
-          if (!triggerOnce) {
+          if (repeat) {
             setIsIntersecting(false);
           }
         }
@@ -57,7 +57,7 @@ export const useIntersectionObserver = <T extends Element>(
     return () => {
       observer.unobserve(element);
     };
-  }, [ref, threshold, root, rootMargin, triggerOnce]);
+  }, [ref, threshold, root, rootMargin, repeat]);
 
   return [ref, isIntersecting];
 };

--- a/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver/useIntersectionObserver.ts
@@ -9,7 +9,7 @@
  * @param {number} [options.threshold=0] - A single number or an array of numbers indicating at what percentage of the target's visibility the observer's callback should be executed.
  * @param {Element | Document | null} [options.root=null] - The element that is used as the viewport for checking intersection. Defaults to the browser viewport if not specified or if null.
  * @param {string} [options.rootMargin='0%'] - Margin around the root. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left).
- * @param {boolean} [options.repeat=false] - If true, the observer will keep observing the element. If false, the observer will unobserve after the first intersection. Defaults to false.
+ * @param {boolean} [options.repeat=true] - If true, the observer will keep observing the element. If false, the observer will unobserve after the first intersection. Defaults to true.
  *
  * @returns {[RefObject<T | null>, boolean]} A tuple containing:
  * - `ref`: A RefObject to be attached to the DOM element you want to observe.
@@ -24,7 +24,7 @@ type IntersectionObserverOptions = {
 export const useIntersectionObserver = <T extends Element>(
   options: IntersectionObserverOptions = {}
 ): [RefObject<T | null>, boolean] => {
-  const { threshold = 0, root = null, rootMargin = '0%', repeat = false } = options;
+  const { threshold = 0, root = null, rootMargin = '0%', repeat = true } = options;
   const ref = useRef<T>(null);
   const [isIntersecting, setIsIntersecting] = useState(false);
 


### PR DESCRIPTION
---
name: Pull Request
about: Describe your changes
---

## Description

Added `repeat` prop to `TextMotion` and `NodeMotion` components.  
When `repeat={true}`, the animation now re-triggers every time the component appears on the screen.

## Related Issue

Closes #48 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the project style guidelines
- [x] I performed a self-review of my own code
- [x] I added tests that prove my fix is effective
- [x] I added necessary documentation
