### PR TITLE
feat: add `initialDelay` prop for animation start delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Animate **plain text strings** with per-character, word, or line animations.
   text="Hello World!"
   split="character"
   trigger="scroll"
+  repeat={false}
+  initialDelay={0.5}
   motion={{
     fade: {
       variant: 'in',
@@ -89,6 +91,7 @@ Animate **any React children** (mixed tags, custom components, blocks).
   split="character"
   trigger="scroll"
   repeat={false}
+  initialDelay={0.5}
   motion={{
     fade: {
       variant: 'in',
@@ -108,14 +111,15 @@ Animate **any React children** (mixed tags, custom components, blocks).
 
 ## API Reference
 
-| Prop      | Type                              | Default       | Description                  |
-| --------- | --------------------------------- | ------------- | ---------------------------- |
-| `as`      | `string`                          | `"span"`      | HTML tag wrapper             |
-| `split`   | `"character" \| "word" \| "line"` | `"character"` | Text split granularity       |
-| `trigger` | `"on-load" \| "scroll"`           | `"scroll"`    | When animation starts        |
-| `repeat`  | `boolean`                         | `true`        | Repeat entire animation      |
-| `motion`  | `MotionConfig`                    | `-`           | Custom animation config      |
-| `preset`  | `AnimationPreset[]`               | `-`           | Predefined animation presets |
+| Prop           | Type                              | Default       | Description                                    |
+| -------------- | --------------------------------- | ------------- | ---------------------------------------------- |
+| `as`           | `string`                          | `"span"`      | HTML tag wrapper                               |
+| `split`        | `"character" \| "word" \| "line"` | `"character"` | Text split granularity                         |
+| `trigger`      | `"on-load" \| "scroll"`           | `"scroll"`    | When animation starts                          |
+| `repeat`       | `boolean`                         | `true`        | Repeat entire animation                        |
+| `initialDelay` | `number`                          | `0`           | Initial delay before animation starts (in `s`) |
+| `motion`       | `MotionConfig`                    | `-`           | Custom animation config                        |
+| `preset`       | `AnimationPreset[]`               | `-`           | Predefined animation presets                   |
 
 <!-- > Full details: [API Docs](./docs/API.md) -->
 

--- a/src/components/AnimatedSpan/AnimatedSpan.tsx
+++ b/src/components/AnimatedSpan/AnimatedSpan.tsx
@@ -6,6 +6,7 @@ import { generateAnimation } from '../../utils/generateAnimation';
 
 type AnimatedSpanProps = {
   splittedText: string[];
+  initialDelay?: number;
   motion?: MotionConfig;
   preset?: AnimationPreset[];
   sequenceIndex?: number;
@@ -22,11 +23,17 @@ type AnimatedSpanProps = {
  *
  * @returns {JSX.Element} A React element `<span>` with inline animation styles.
  */
-export const AnimatedSpan: FC<AnimatedSpanProps> = ({ splittedText, motion, preset, sequenceIndex = 0 }) => {
+export const AnimatedSpan: FC<AnimatedSpanProps> = ({
+  splittedText,
+  initialDelay = 0,
+  motion,
+  preset,
+  sequenceIndex = 0,
+}) => {
   const resolvedMotion = useResolvedMotion(motion, preset);
 
   return splittedText.map((text, index) => {
-    const { style } = generateAnimation(resolvedMotion, index + sequenceIndex);
+    const { style } = generateAnimation(resolvedMotion, index + sequenceIndex, initialDelay);
 
     if (text === '\n') {
       return <br key={`${text}-${index}`} />;

--- a/src/components/AnimatedSpan/AnimatedSpan.tsx
+++ b/src/components/AnimatedSpan/AnimatedSpan.tsx
@@ -17,6 +17,7 @@ type AnimatedSpanProps = {
  * `AnimatedSpan` is a component that creates a `<span>` element with animation styles.
  *
  * @param {string} splittedText - The array of substrings based on the specified split type.
+ * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  * @param {MotionConfig} motion - The motion configuration to generate animation styles from.
  * @param {AnimationPreset[]} preset - The animation presets to apply.
  * @param {number} sequenceIndex - The index of the element in the animation sequence.

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -19,6 +19,7 @@ import { handleValidation, validateNodeMotionProps } from '../../utils/validatio
  * @param {SplitType} [split='character'] - Defines how the text is split for animation (`character` or `word`). Defaults to `'character'`.
  * @param {'on-load' | 'scroll'} [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
  * @param {boolean} [repeat=true] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
+ * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -57,7 +57,16 @@ import { handleValidation, validateNodeMotionProps } from '../../utils/validatio
  * }
  */
 export const NodeMotion: FC<NodeMotionProps> = memo(props => {
-  const { as: Tag = 'span', children, split = 'character', trigger = 'scroll', motion, preset, repeat = true } = props;
+  const {
+    as: Tag = 'span',
+    children,
+    split = 'character',
+    trigger = 'scroll',
+    repeat = true,
+    initialDelay = 0,
+    motion,
+    preset,
+  } = props;
 
   const { errors, warnings } = validateNodeMotionProps(props);
   handleValidation(errors, warnings);
@@ -66,7 +75,7 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
   const shouldAnimate = trigger === 'on-load' || isIntersecting;
 
   const accessibleText = useTextFromReactNode(children);
-  const animatedNode = useAnimatedNode(children, split, motion, preset);
+  const animatedNode = useAnimatedNode(children, split, initialDelay, motion, preset);
 
   return (
     <Tag ref={targetRef} className="node-motion" aria-label={accessibleText}>

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -57,7 +57,16 @@ import { handleValidation, validateTextMotionProps } from '../../utils/validatio
  */
 
 export const TextMotion: FC<TextMotionProps> = memo(props => {
-  const { as: Tag = 'span', text, split = 'character', trigger = 'scroll', motion, preset, repeat = true } = props;
+  const {
+    as: Tag = 'span',
+    text,
+    split = 'character',
+    trigger = 'scroll',
+    repeat = true,
+    initialDelay = 0,
+    motion,
+    preset,
+  } = props;
 
   const { errors, warnings } = validateTextMotionProps(props);
   handleValidation(errors, warnings);
@@ -69,7 +78,11 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
 
   return (
     <Tag ref={targetRef} className="text-motion" aria-label={text}>
-      {shouldAnimate ? <AnimatedSpan splittedText={splittedText} motion={motion} preset={preset} /> : text}
+      {shouldAnimate ? (
+        <AnimatedSpan splittedText={splittedText} initialDelay={initialDelay} motion={motion} preset={preset} />
+      ) : (
+        text
+      )}
     </Tag>
   );
 });

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -20,6 +20,7 @@ import { handleValidation, validateTextMotionProps } from '../../utils/validatio
  * @param {SplitType} [split='character'] - Defines how the text is split for animation (`character`, `word`, or `line`). Defaults to `'character'`.
  * @param {'on-load' | 'scroll' } [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
  * @param {boolean} [repeat=true] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
+ * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *
@@ -34,6 +35,7 @@ import { handleValidation, validateTextMotionProps } from '../../utils/validatio
  *       split="character"
  *       trigger="scroll"
  *       repeat={false}
+ *       initialDelay={1}
  *       motion={{
  *         fade: { variant: 'in', duration: 0.25, delay: 0.025, easing: 'linear' },
  *         slide: { variant: 'up', duration: 0.25, delay: 0.025, easing: 'linear' },
@@ -50,6 +52,7 @@ import { handleValidation, validateTextMotionProps } from '../../utils/validatio
  *       text="Hello World!"
  *       split="word"
  *       trigger="on-load"
+ *       initialDelay={0.5}
  *       preset={['fade-in', 'slide-up']}
  *     />
  *   );

--- a/src/hooks/useAnimatedNode/animateNode.spec.tsx
+++ b/src/hooks/useAnimatedNode/animateNode.spec.tsx
@@ -6,13 +6,14 @@ import { animateNode } from './animateNode';
 
 describe('animateNode utility', () => {
   const split = 'character';
+  const initialDelay = 0;
   const motion: MotionConfig = {};
   const preset: AnimationPreset[] = [];
   const sequenceIndex = 0;
 
   it('splits string into animated spans', () => {
     const node = 'Hi';
-    const result = animateNode(node, split, motion, preset, sequenceIndex);
+    const result = animateNode(node, split, initialDelay, motion, preset, sequenceIndex);
 
     const { container } = render(<>{result.nodes}</>);
     const spans = container.querySelectorAll('span');
@@ -25,7 +26,7 @@ describe('animateNode utility', () => {
 
   it('splits number into animated spans', () => {
     const node = 123;
-    const result = animateNode(node, split, motion, preset, sequenceIndex);
+    const result = animateNode(node, split, initialDelay, motion, preset, sequenceIndex);
 
     const { container } = render(<>{result.nodes}</>);
     const spans = container.querySelectorAll('span');
@@ -39,7 +40,7 @@ describe('animateNode utility', () => {
 
   it('handles node without sequenceIndex', () => {
     const node = '1';
-    const result = animateNode(node, split, motion, preset);
+    const result = animateNode(node, split, initialDelay, motion, preset);
 
     const { container } = render(<>{result.nodes}</>);
     const spans = container.querySelectorAll('span');
@@ -51,7 +52,7 @@ describe('animateNode utility', () => {
 
   it('recursively handles nested elements', () => {
     const node = <strong>Hello</strong>;
-    const result = animateNode(node, split, motion, preset, sequenceIndex);
+    const result = animateNode(node, split, initialDelay, motion, preset, sequenceIndex);
 
     const { container } = render(<>{result.nodes}</>);
     const strong = container.querySelector('strong') as HTMLElement;
@@ -64,7 +65,7 @@ describe('animateNode utility', () => {
 
   it('handles arrays of nodes', () => {
     const node = ['Hello', ' ', 'World'];
-    const result = animateNode(node, split, motion, preset, sequenceIndex);
+    const result = animateNode(node, split, initialDelay, motion, preset, sequenceIndex);
 
     const { container } = render(<>{result.nodes}</>);
     const spans = container.querySelectorAll('span');
@@ -77,8 +78,8 @@ describe('animateNode utility', () => {
     const nullNode = null;
     const booleanNode = true;
 
-    const nullResult = animateNode(nullNode, split, motion, preset, sequenceIndex);
-    const booleanResult = animateNode(booleanNode, split, motion, preset, sequenceIndex);
+    const nullResult = animateNode(nullNode, split, initialDelay, motion, preset, sequenceIndex);
+    const booleanResult = animateNode(booleanNode, split, initialDelay, motion, preset, sequenceIndex);
 
     expect(nullResult.nodes).toEqual([]);
     expect(nullResult.count).toBe(sequenceIndex);
@@ -89,7 +90,7 @@ describe('animateNode utility', () => {
 
   it('handles unknown node types by returning the node as-is', () => {
     const unknownNode = Symbol('test');
-    const result = animateNode(unknownNode as any, 'character', {}, [], 0);
+    const result = animateNode(unknownNode as any, split, initialDelay, motion, preset, sequenceIndex);
 
     expect(result.nodes).toEqual([unknownNode]);
     expect(result.count).toBe(0);

--- a/src/hooks/useAnimatedNode/animateNode.tsx
+++ b/src/hooks/useAnimatedNode/animateNode.tsx
@@ -20,6 +20,7 @@ import { splitText } from '../../utils/splitText';
 export const animateNode = (
   node: ReactNode,
   split: SplitType,
+  initialDelay: number,
   motion?: MotionConfig,
   preset?: AnimationPreset[],
   sequenceIndex: number = 0
@@ -33,6 +34,7 @@ export const animateNode = (
         <AnimatedSpan
           key={`${text}-${sequenceIndex}`}
           splittedText={splittedText}
+          initialDelay={initialDelay}
           motion={motion}
           preset={preset}
           sequenceIndex={sequenceIndex}
@@ -45,7 +47,14 @@ export const animateNode = (
   if (Array.isArray(node)) {
     return node.reduce(
       (acc, child) => {
-        const { nodes: childNodes, count } = animateNode(child, split, motion, preset, sequenceIndex + acc.count);
+        const { nodes: childNodes, count } = animateNode(
+          child,
+          split,
+          initialDelay,
+          motion,
+          preset,
+          sequenceIndex + acc.count
+        );
 
         acc.nodes.push(...childNodes);
         acc.count += count;
@@ -57,7 +66,14 @@ export const animateNode = (
   }
 
   if (isValidElement<{ children?: ReactNode }>(node)) {
-    const { nodes: childrenNodes, count } = animateNode(node.props.children, split, motion, preset, sequenceIndex);
+    const { nodes: childrenNodes, count } = animateNode(
+      node.props.children,
+      split,
+      initialDelay,
+      motion,
+      preset,
+      sequenceIndex
+    );
 
     return {
       nodes: [cloneElement(node, { key: sequenceIndex, children: childrenNodes })],

--- a/src/hooks/useAnimatedNode/animateNode.tsx
+++ b/src/hooks/useAnimatedNode/animateNode.tsx
@@ -11,6 +11,7 @@ import { splitText } from '../../utils/splitText';
  *
  * @param {ReactNode} node - The React node to process.
  * @param {SplitType} split - The split type for text animations (`character` or `word`).
+ * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  * @param {MotionConfig} motion - The motion configuration to apply.
  * @param {AnimationPreset[]} preset - The animation presets to apply.
  * @param {number} sequenceIndex - The starting sequence index for the animation.

--- a/src/hooks/useAnimatedNode/useAnimatedNode.spec.tsx
+++ b/src/hooks/useAnimatedNode/useAnimatedNode.spec.tsx
@@ -5,13 +5,14 @@ import { AnimationPreset, MotionConfig } from '../../types';
 import { useAnimatedNode } from './useAnimatedNode';
 
 describe('useAnimatedNode hook', () => {
+  const split = 'character';
+  const initialDelay = 0;
   const motion: MotionConfig = {};
   const preset: AnimationPreset[] = [];
-  const split = 'character';
 
   it('generates animated spans for string children', () => {
     const children = 'Hey';
-    const { result } = renderHook(() => useAnimatedNode(children, split, motion, preset));
+    const { result } = renderHook(() => useAnimatedNode(children, split, initialDelay, motion, preset));
 
     const { container } = render(<>{result.current}</>);
     const spans = container.querySelectorAll('span');
@@ -22,7 +23,7 @@ describe('useAnimatedNode hook', () => {
 
   it('handles nested React elements with text', () => {
     const children = <p>Hello</p>;
-    const { result } = renderHook(() => useAnimatedNode(children, split, motion, preset));
+    const { result } = renderHook(() => useAnimatedNode(children, split, initialDelay, motion, preset));
 
     const { container } = render(<>{result.current}</>);
     const paragraph = container.querySelector('p') as HTMLElement;
@@ -34,7 +35,7 @@ describe('useAnimatedNode hook', () => {
 
   it('resets sequenceIndexRef for each call', () => {
     const children = 'Hi';
-    const { result } = renderHook(() => useAnimatedNode(children, split, motion, preset));
+    const { result } = renderHook(() => useAnimatedNode(children, split, initialDelay, motion, preset));
 
     const { container } = render(<>{result.current}</>);
     const spans = container.querySelectorAll('span');

--- a/src/hooks/useAnimatedNode/useAnimatedNode.ts
+++ b/src/hooks/useAnimatedNode/useAnimatedNode.ts
@@ -12,6 +12,7 @@ import { animateNode } from './animateNode';
  *
  * @param {ReactNode} children - The React children to be animated.
  * @param {SplitType} split - The split type for text animations (`character` or `word`).
+ * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  * @param {MotionConfig} motion - The motion configuration object, which is a result of merging custom motion and presets.
  * @param {AnimationPreset[]} preset - The animation presets to apply.
  *

--- a/src/hooks/useAnimatedNode/useAnimatedNode.ts
+++ b/src/hooks/useAnimatedNode/useAnimatedNode.ts
@@ -20,6 +20,7 @@ import { animateNode } from './animateNode';
 export const useAnimatedNode = (
   children: ReactNode,
   split: SplitType,
+  initialDelay: number,
   motion?: MotionConfig,
   preset?: AnimationPreset[]
 ) => {
@@ -28,14 +29,14 @@ export const useAnimatedNode = (
     const collectedNodes: ReactNode[] = [];
 
     Children.forEach(children, child => {
-      const { nodes, count } = animateNode(child, split, motion, preset, sequenceIndex);
+      const { nodes, count } = animateNode(child, split, initialDelay, motion, preset, sequenceIndex);
 
       collectedNodes.push(...nodes);
       sequenceIndex += count;
     });
 
     return collectedNodes;
-  }, [children, split, motion, preset]);
+  }, [children, split, initialDelay, motion, preset]);
 
   return animatedNode;
 };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -8,6 +8,7 @@ export type BaseMotionProps = {
   split?: SplitType;
   trigger?: 'on-load' | 'scroll';
   repeat?: boolean;
+  initialDelay?: number;
 };
 
 export type MotionProps =

--- a/src/utils/generateAnimation/generateAnimation.spec.ts
+++ b/src/utils/generateAnimation/generateAnimation.spec.ts
@@ -8,7 +8,7 @@ describe('generateAnimation utility', () => {
       const motion: MotionConfig = {
         fade: { variant: 'in', duration: 2, delay: 1 },
       };
-      const { style } = generateAnimation(motion, 0);
+      const { style } = generateAnimation(motion, 0, 0);
 
       expect(style.animation).toBe('fade-in 2s ease-out 0s both');
     });
@@ -17,7 +17,7 @@ describe('generateAnimation utility', () => {
       const motion: MotionConfig = {
         fade: { variant: 'out', duration: 1.5, delay: 0.5 },
       };
-      const { style } = generateAnimation(motion, 2);
+      const { style } = generateAnimation(motion, 2, 0);
 
       expect(style.animation).toBe('fade-out 1.5s ease-out 1s both');
     });
@@ -27,7 +27,7 @@ describe('generateAnimation utility', () => {
         fade: { variant: 'in', duration: 2, delay: 1 },
         slide: { variant: 'up', duration: 3, delay: 0.5 },
       };
-      const { style } = generateAnimation(motion, 2);
+      const { style } = generateAnimation(motion, 2, 0);
 
       expect(style.animation).toBe('fade-in 2s ease-out 2s both, slide-up 3s ease-out 1s both');
     });
@@ -36,7 +36,7 @@ describe('generateAnimation utility', () => {
       const motion: MotionConfig = {
         fade: { variant: 'in', duration: 2, delay: 1, easing: 'ease-in-out' },
       };
-      const { style } = generateAnimation(motion, 0);
+      const { style } = generateAnimation(motion, 0, 0);
 
       expect(style.animation).toBe('fade-in 2s ease-in-out 0s both');
     });
@@ -45,7 +45,7 @@ describe('generateAnimation utility', () => {
       const motion: MotionConfig = {
         slide: { variant: 'up', duration: 1, delay: 0, distance: '100px' },
       };
-      const { style } = generateAnimation(motion, 0);
+      const { style } = generateAnimation(motion, 0, 0);
 
       expect(style).toHaveProperty('--slide-distance', '100px');
       expect(style.animation).toBe('slide-up 1s ease-out 0s both');
@@ -55,7 +55,7 @@ describe('generateAnimation utility', () => {
       const motion: MotionConfig = {
         slide: { variant: 'up', duration: 1, delay: 0, distance: undefined },
       };
-      const { style } = generateAnimation(motion, 0);
+      const { style } = generateAnimation(motion, 0, 0);
 
       expect(style).not.toHaveProperty('--slide-distance');
       expect(style.animation).toBe('slide-up 1s ease-out 0s both');
@@ -85,7 +85,7 @@ describe('generateAnimation utility', () => {
     ];
 
     it.each(testCases)('should handle %s correctly', (_, motion, expected) => {
-      const { style } = generateAnimation(motion, 0);
+      const { style } = generateAnimation(motion, 0, 0);
 
       expect(style.animation).toBe(expected);
     });
@@ -98,7 +98,7 @@ describe('generateAnimation utility', () => {
 
       motionsWithPrototype.ownMotion = { variant: 'out', duration: 2, delay: 0.5 };
 
-      const { style } = generateAnimation(motionsWithPrototype, 1);
+      const { style } = generateAnimation(motionsWithPrototype, 1, 0);
 
       expect(style.animation).toBe('ownMotion-out 2s ease-out 0.5s both');
     });

--- a/src/utils/generateAnimation/generateAnimation.ts
+++ b/src/utils/generateAnimation/generateAnimation.ts
@@ -16,13 +16,17 @@ type StyleWithCustomProperties = CSSProperties & {
  *
  * @returns {{ style: StyleWithCustomProperties }} An object containing the generated CSS styles.
  */
-export const generateAnimation = (motionConfig: MotionConfig, index: number): { style: StyleWithCustomProperties } => {
+export const generateAnimation = (
+  motionConfig: MotionConfig,
+  index: number,
+  initialDelay: number
+): { style: StyleWithCustomProperties } => {
   const { animations, style } = Object.entries(motionConfig).reduce(
     (acc, [name, animation]) => {
       if (!animation || !('variant' in animation)) return acc;
 
       const { variant, duration, delay, easing = 'ease-out', ...rest } = animation;
-      const calculatedDelay = index * delay;
+      const calculatedDelay = index * delay + initialDelay;
 
       const animationString = `${name}-${variant} ${duration}s ${easing} ${calculatedDelay}s both`;
       acc.animations.push(animationString);

--- a/src/utils/generateAnimation/generateAnimation.ts
+++ b/src/utils/generateAnimation/generateAnimation.ts
@@ -13,6 +13,7 @@ type StyleWithCustomProperties = CSSProperties & {
  *
  * @param {MotionConfig} motionConfig - The motion configuration object.
  * @param {number} index - The index of the element in the animation sequence, used to calculate the animation delay.
+ * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  *
  * @returns {{ style: StyleWithCustomProperties }} An object containing the generated CSS styles.
  */


### PR DESCRIPTION
## Description

Added `initialDelay` prop to `TextMotion` and `NodeMotion` components.  
This prop allows setting an initial delay (in `seconds`) before the entire animation starts, improving control when sequencing multiple animations.
Default is `0`.

## Related Issue

Closes #51 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the project style guidelines
- [x] I performed a self-review of my own code
- [x] I added tests that prove my fix is effective
- [x] I added necessary documentation
