### PR TITLE
feat: add `animationOrder` prop for controlling animation sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,16 @@ Animate **any React children** (mixed tags, custom components, blocks).
 
 ## API Reference
 
-| Prop           | Type                              | Default       | Description                                    |
-| -------------- | --------------------------------- | ------------- | ---------------------------------------------- |
-| `as`           | `string`                          | `"span"`      | HTML tag wrapper                               |
-| `split`        | `"character" \| "word" \| "line"` | `"character"` | Text split granularity                         |
-| `trigger`      | `"on-load" \| "scroll"`           | `"scroll"`    | When animation starts                          |
-| `repeat`       | `boolean`                         | `true`        | Repeat entire animation                        |
-| `initialDelay` | `number`                          | `0`           | Initial delay before animation starts (in `s`) |
-| `motion`       | `MotionConfig`                    | `-`           | Custom animation config                        |
-| `preset`       | `AnimationPreset[]`               | `-`           | Predefined animation presets                   |
+| Prop             | Type                              | Default         | Description                                    |
+| ---------------- | --------------------------------- | --------------- | ---------------------------------------------- |
+| `as`             | `string`                          | `"span"`        | HTML tag wrapper                               |
+| `split`          | `"character" \| "word" \| "line"` | `"character"`   | Text split granularity                         |
+| `trigger`        | `"on-load" \| "scroll"`           | `"scroll"`      | When animation starts                          |
+| `repeat`         | `boolean`                         | `true`          | Repeat entire animation                        |
+| `initialDelay`   | `number`                          | `0`             | Initial delay before animation starts (in `s`) |
+| `animationOrder` | `AnimationOrder`                  | `first-to-last` | Order of the animation sequence                |
+| `motion`         | `MotionConfig`                    | `-`             | Custom animation config                        |
+| `preset`         | `AnimationPreset[]`               | `-`             | Predefined animation presets                   |
 
 <!-- > Full details: [API Docs](./docs/API.md) -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-textmotion",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Lightweight yet powerful library that provides variable animation effects for React applications.",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/src/components/AnimatedSpan/AnimatedSpan.tsx
+++ b/src/components/AnimatedSpan/AnimatedSpan.tsx
@@ -9,7 +9,7 @@ type AnimatedSpanProps = {
 
 /**
  * @description
- * `AnimatedSpan` is a component that creates a `<span>` element with animation styles.
+ * `AnimatedSpan` is a component that animates a text node by creating a `<span>` element with animation styles.
  *
  * @param {string} text - The text content to animate.
  * @param {StyleWithCustomProperties} style - The inline styles to apply to the `<span>` element.

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -21,6 +21,7 @@ import { handleValidation, validateNodeMotionProps } from '../../utils/validatio
  * @param {'on-load' | 'scroll'} [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
  * @param {boolean} [repeat=true] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
  * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
+ * @param {'first-to-last' | 'last-to-first'} [animationOrder='first-to-last'] - Defines the order in which the animation sequence is applied. Defaults to `'first-to-last'`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -66,6 +66,7 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
     trigger = 'scroll',
     repeat = true,
     initialDelay = 0,
+    animationOrder = 'first-to-last',
     motion,
     preset,
   } = props;
@@ -78,7 +79,7 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
 
   const { splittedNode, text } = splitNodeAndExtractText(children, split);
   const resolvedMotion = useResolvedMotion(motion, preset);
-  const animatedNode = useAnimatedNode(splittedNode, initialDelay, resolvedMotion);
+  const animatedNode = useAnimatedNode(splittedNode, initialDelay, animationOrder, resolvedMotion);
 
   return (
     <Tag ref={targetRef} className="node-motion" aria-label={text}>

--- a/src/components/TextMotion/TextMotion.spec.tsx
+++ b/src/components/TextMotion/TextMotion.spec.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import * as useIntersectionObserver from '../../hooks/useIntersectionObserver';
+import * as generateAnimationModule from '../../utils/generateAnimation';
 
 import { TextMotion } from './TextMotion';
 
@@ -75,5 +76,32 @@ describe('TextMotion component', () => {
     render(<TextMotion text="" />);
 
     expect(consoleWarnSpy).toHaveBeenCalled();
+  });
+});
+
+describe('TextMotion animationOrder', () => {
+  const TEXT = 'ABC';
+  const generateAnimationSpy = jest.spyOn(generateAnimationModule, 'generateAnimation');
+
+  beforeEach(() => {
+    generateAnimationSpy.mockClear();
+  });
+
+  it('should calculate sequenceIndex in first-to-last order', () => {
+    render(<TextMotion text={TEXT} animationOrder="first-to-last" />);
+
+    expect(generateAnimationSpy).toHaveBeenNthCalledWith(1, expect.anything(), 0, 0);
+    expect(generateAnimationSpy).toHaveBeenNthCalledWith(2, expect.anything(), 1, 0);
+    expect(generateAnimationSpy).toHaveBeenNthCalledWith(3, expect.anything(), 2, 0);
+  });
+
+  it('should calculate sequenceIndex in last-to-first order', () => {
+    const generateAnimationSpy = jest.spyOn(generateAnimationModule, 'generateAnimation');
+
+    render(<TextMotion text={TEXT} animationOrder="last-to-first" />);
+
+    expect(generateAnimationSpy).toHaveBeenNthCalledWith(1, expect.anything(), 2, 0);
+    expect(generateAnimationSpy).toHaveBeenNthCalledWith(2, expect.anything(), 1, 0);
+    expect(generateAnimationSpy).toHaveBeenNthCalledWith(3, expect.anything(), 0, 0);
   });
 });

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -60,7 +60,6 @@ import { handleValidation, validateTextMotionProps } from '../../utils/validatio
  *   );
  * }
  */
-
 export const TextMotion: FC<TextMotionProps> = memo(props => {
   const {
     as: Tag = 'span',
@@ -69,6 +68,7 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
     trigger = 'scroll',
     repeat = true,
     initialDelay = 0,
+    animationOrder = 'first-to-last',
     motion,
     preset,
   } = props;
@@ -82,7 +82,8 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
   const splittedText = splitText(text, split);
   const resolvedMotion = useResolvedMotion(motion, preset);
   const animatedNode = splittedText.map((text, index) => {
-    const { style } = generateAnimation(resolvedMotion, index, initialDelay);
+    const sequenceIndex = animationOrder === 'first-to-last' ? index : splittedText.length - (index + 1);
+    const { style } = generateAnimation(resolvedMotion, sequenceIndex, initialDelay);
 
     return <AnimatedSpan key={index} text={text} style={style} />;
   });

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -23,6 +23,7 @@ import { handleValidation, validateTextMotionProps } from '../../utils/validatio
  * @param {'on-load' | 'scroll' } [trigger='scroll'] - Defines when the animation should start. 'on-load' starts the animation immediately. 'scroll' starts the animation only when the component enters the viewport. Defaults to `'scroll'`.
  * @param {boolean} [repeat=true] - Determines if the animation should repeat every time it enters the viewport. Only applicable when `trigger` is `'scroll'`. Defaults to `true`.
  * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
+ * @param {'first-to-last' | 'last-to-first'} [animationOrder='first-to-last'] - Defines the order in which the animation sequence is applied. Defaults to `'first-to-last'`.
  * @param {MotionConfig} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {AnimationPreset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  *

--- a/src/hooks/useAnimatedNode/useAnimatedNode.tsx
+++ b/src/hooks/useAnimatedNode/useAnimatedNode.tsx
@@ -1,7 +1,7 @@
 import { Children, cloneElement, isValidElement, ReactNode, useMemo } from 'react';
 
 import { AnimatedSpan } from '../../components/AnimatedSpan';
-import { MotionConfig } from '../../types';
+import { AnimationOrder, MotionConfig } from '../../types';
 import { generateAnimation } from '../../utils/generateAnimation';
 
 /**
@@ -18,29 +18,51 @@ import { generateAnimation } from '../../utils/generateAnimation';
 export const useAnimatedNode = (
   splittedNode: ReactNode[],
   initialDelay: number,
+  animationOrder: AnimationOrder,
   resolvedMotion: MotionConfig
 ): ReactNode[] => {
   const animatedNode = useMemo(() => {
+    const totalNodes = countNodes(splittedNode);
     const sequenceIndexRef = { current: 0 };
 
-    return wrapWithAnimatedSpan(splittedNode, initialDelay, resolvedMotion, sequenceIndexRef);
-  }, [splittedNode, initialDelay, resolvedMotion]);
+    return wrapWithAnimatedSpan(
+      splittedNode,
+      initialDelay,
+      animationOrder,
+      resolvedMotion,
+      totalNodes,
+      sequenceIndexRef
+    );
+  }, [splittedNode, initialDelay, animationOrder, resolvedMotion]);
 
   return animatedNode;
+};
+
+const countNodes = (nodes: ReactNode[]): number => {
+  return Children.toArray(nodes).reduce((count: number, node: ReactNode) => {
+    if (isValidElement<{ children?: ReactNode }>(node)) {
+      return count + 1 + countNodes(Children.toArray(node.props.children));
+    }
+
+    return count + 1;
+  }, 0);
 };
 
 export const wrapWithAnimatedSpan = (
   splittedNode: ReactNode[],
   initialDelay: number,
+  animationOrder: AnimationOrder,
   resolvedMotion: MotionConfig,
+  totalNodes: number,
   sequenceIndexRef?: { current: number }
 ): ReactNode[] => {
   return splittedNode.map(node => {
     const currentIndex = sequenceIndexRef!.current++;
+    const animationIndex = animationOrder === 'last-to-first' ? totalNodes - 1 - currentIndex : currentIndex;
 
     if (typeof node === 'string' || typeof node === 'number') {
       return [String(node)].map(text => {
-        const { style } = generateAnimation(resolvedMotion, currentIndex, initialDelay);
+        const { style } = generateAnimation(resolvedMotion, animationIndex, initialDelay);
 
         return <AnimatedSpan key={currentIndex} text={text} style={style} />;
       });
@@ -48,7 +70,14 @@ export const wrapWithAnimatedSpan = (
 
     if (isValidElement<{ children?: ReactNode }>(node)) {
       const childArray = Children.toArray(node.props.children);
-      const animatedChildren = wrapWithAnimatedSpan(childArray, initialDelay, resolvedMotion, sequenceIndexRef);
+      const animatedChildren = wrapWithAnimatedSpan(
+        childArray,
+        initialDelay,
+        animationOrder,
+        resolvedMotion,
+        totalNodes,
+        sequenceIndexRef
+      );
 
       return cloneElement(node, { ...node.props, children: animatedChildren, key: currentIndex });
     }

--- a/src/hooks/useAnimatedNode/useAnimatedNode.tsx
+++ b/src/hooks/useAnimatedNode/useAnimatedNode.tsx
@@ -11,6 +11,7 @@ import { generateAnimation } from '../../utils/generateAnimation';
  *
  * @param {ReactNode[]} splittedNode - The array of React nodes to be animated.
  * @param {number} initialDelay - The initial delay before the animation starts, in seconds.
+ * @param {AnimationOrder} animationOrder - Defines the order in which the animation sequence is applied. Defaults to `'first-to-last'`.
  * @param {MotionConfig} resolvedMotion - The motion configuration object, which is a result of merging custom motion and presets.
  *
  * @returns {ReactNode[]} An array of animated React nodes.

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -20,6 +20,14 @@ export type SplitType = 'character' | 'word' | 'line';
 
 /**
  * @description
+ * Defines the order of animation.
+ * - `first-to-last`: Animates from the first element to the last element.
+ * - `last-to-first`: Animates from the last element to the first element.
+ */
+export type AnimationOrder = 'first-to-last' | 'last-to-first';
+
+/**
+ * @description
  * A configuration object that defines the animations to be applied.
  * Each property corresponds to a type of animation and holds its specific configuration.
  *
@@ -43,6 +51,13 @@ export type MotionConfig = {
   [key: string]: CustomAnimation | undefined;
 };
 
+/**
+ * @description
+ * A configuration object that defines the validation result.
+ *
+ * @property {string[]} errors - An array of error messages.
+ * @property {string[]} warnings - An array of warning messages.
+ */
 export type ValidationResult = {
   errors: string[];
   warnings: string[];

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,6 +1,6 @@
 import { ElementType, ReactNode } from 'react';
 
-import { MotionConfig, SplitType } from './common';
+import { AnimationOrder, MotionConfig, SplitType } from './common';
 import { AnimationPreset } from './preset';
 
 export type BaseMotionProps = {
@@ -9,6 +9,7 @@ export type BaseMotionProps = {
   trigger?: 'on-load' | 'scroll';
   repeat?: boolean;
   initialDelay?: number;
+  animationOrder?: AnimationOrder;
 };
 
 export type MotionProps =

--- a/src/utils/generateAnimation/generateAnimation.ts
+++ b/src/utils/generateAnimation/generateAnimation.ts
@@ -12,14 +12,14 @@ export type StyleWithCustomProperties = CSSProperties & {
  * It creates the `animation` property and any custom CSS properties needed for the animations.
  *
  * @param {MotionConfig} motionConfig - The motion configuration object.
- * @param {number} index - The index of the element in the animation sequence, used to calculate the animation delay.
+ * @param {number} sequenceIndex - The index of the element in the animation sequence, used to calculate the animation delay.
  * @param {number} [initialDelay=0] - The initial delay before the animation starts, in seconds. Defaults to `0`.
  *
  * @returns {{ style: StyleWithCustomProperties }} An object containing the generated CSS styles.
  */
 export const generateAnimation = (
   motionConfig: MotionConfig,
-  index: number,
+  sequenceIndex: number,
   initialDelay: number
 ): { style: StyleWithCustomProperties } => {
   const { animations, style } = Object.entries(motionConfig).reduce(
@@ -27,7 +27,7 @@ export const generateAnimation = (
       if (!animation || !('variant' in animation)) return acc;
 
       const { variant, duration, delay, easing = 'ease-out', ...rest } = animation;
-      const calculatedDelay = index * delay + initialDelay;
+      const calculatedDelay = sequenceIndex * delay + initialDelay;
 
       const animationString = `${name}-${variant} ${duration}s ${easing} ${calculatedDelay}s both`;
       acc.animations.push(animationString);


### PR DESCRIPTION
## Description

Added a new `animationOrder` prop to the `TextMotion` and `NodeMotion` components, allowing developers to control the sequence of animations.  
The prop accepts the following values:  
- `'first-to-last'` (default): Animate elements from start to end.  
- `'last-to-first'`: Animate elements from end to start.  

This change provides more flexibility in creating dynamic and visually appealing animations.

## Related Issue

Closes #52 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the project style guidelines
- [x] I performed a self-review of my own code
- [x] I added tests that prove my fix is effective
- [x] I added necessary documentation






