### PR TITLE
feat: add `onAnimationStart` and `onAnimationEnd` callback props

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Animate **plain text strings** with per-character, word, or line animations.
       easing: 'linear',
     },
   }}
+  onAnimationStart={() => console.log('Animation started')}
+  onAnimationEnd={() => console.log('Animation ended')}
 />
 ```
 
@@ -111,6 +113,8 @@ Animate **any React children** (mixed tags, custom components, blocks).
       easing: 'linear',
     },
   }}
+  onAnimationStart={() => console.log('Animation started')}
+  onAnimationEnd={() => console.log('Animation ended')}
 >
   <span>Hello</span> <b>World!</b>
 </NodeMotion>
@@ -120,31 +124,35 @@ Animate **any React children** (mixed tags, custom components, blocks).
 
 ### TextMotion Props
 
-| Prop             | Type                                 | Default         | Required                | Description                                    |
-| ---------------- | ------------------------------------ | --------------- | ----------------------- | ---------------------------------------------- |
-| `text`           | `string`                             | `-`             | Yes                     | Text to animate                                |
-| `as`             | `string`                             | `"span"`        | No                      | HTML tag wrapper                               |
-| `split`          | `"character" \| "word" \| "line"`    | `"character"`   | No                      | Text split granularity                         |
-| `trigger`        | `"on-load" \| "scroll"`              | `"scroll"`      | No                      | When animation starts                          |
-| `repeat`         | `boolean`                            | `true`          | No                      | Repeat entire animation                        |
-| `initialDelay`   | `number`                             | `0`             | No                      | Initial delay before animation starts (in `s`) |
-| `animationOrder` | `"first-to-last" \| "last-to-first"` | `first-to-last` | No                      | Order of the animation sequence                |
-| `motion`         | `Motion`                             | `-`             | Yes (if `preset` unset) | Custom animation config                        |
-| `preset`         | `Preset[]`                           | `-`             | Yes (if `motion` unset) | Predefined animation presets                   |
+| Prop               | Type                                 | Default         | Required                | Description                                                |
+| ------------------ | ------------------------------------ | --------------- | ----------------------- | ---------------------------------------------------------- |
+| `text`             | `string`                             | `-`             | Yes                     | Text to animate                                            |
+| `as`               | `string`                             | `"span"`        | No                      | HTML tag wrapper                                           |
+| `split`            | `"character" \| "word" \| "line"`    | `"character"`   | No                      | Text split granularity                                     |
+| `trigger`          | `"on-load" \| "scroll"`              | `"scroll"`      | No                      | When animation starts                                      |
+| `repeat`           | `boolean`                            | `true`          | No                      | Repeat entire animation                                    |
+| `initialDelay`     | `number`                             | `0`             | No                      | Initial delay before animation starts (in `s`)             |
+| `animationOrder`   | `"first-to-last" \| "last-to-first"` | `first-to-last` | No                      | Order of the animation sequence                            |
+| `motion`           | `Motion`                             | `-`             | Yes (if `preset` unset) | Custom animation config                                    |
+| `preset`           | `Preset[]`                           | `-`             | Yes (if `motion` unset) | Predefined animation presets                               |
+| `onAnimationStart` | `() => void`                         | `-`             | No                      | Callback function that is called when the animation starts |
+| `onAnimationEnd`   | `() => void`                         | `-`             | No                      | Callback function that is called when the animation ends   |
 
 ### NodeMotion
 
-| Prop             | Type                                 | Default         | Required                | Description                                    |
-| ---------------- | ------------------------------------ | --------------- | ----------------------- | ---------------------------------------------- |
-| `children`       | `ReactNode`                          | `-`             | Yes                     | Content to animate                             |
-| `as`             | `string`                             | `"span"`        | No                      | HTML tag wrapper                               |
-| `split`          | `"character" \| "word"`              | `"character"`   | No                      | Text split granularity                         |
-| `trigger`        | `"on-load" \| "scroll"`              | `"scroll"`      | No                      | When animation starts                          |
-| `repeat`         | `boolean`                            | `true`          | No                      | Repeat entire animation                        |
-| `initialDelay`   | `number`                             | `0`             | No                      | Initial delay before animation starts (in `s`) |
-| `animationOrder` | `"first-to-last" \| "last-to-first"` | `first-to-last` | No                      | Order of the animation sequence                |
-| `motion`         | `Motion`                             | `-`             | Yes (if `preset` unset) | Custom animation config                        |
-| `preset`         | `Preset[]`                           | `-`             | Yes (if `motion` unset) | Predefined animation presets                   |
+| Prop               | Type                                 | Default         | Required                | Description                                                |
+| ------------------ | ------------------------------------ | --------------- | ----------------------- | ---------------------------------------------------------- |
+| `children`         | `ReactNode`                          | `-`             | Yes                     | Content to animate                                         |
+| `as`               | `string`                             | `"span"`        | No                      | HTML tag wrapper                                           |
+| `split`            | `"character" \| "word"`              | `"character"`   | No                      | Text split granularity                                     |
+| `trigger`          | `"on-load" \| "scroll"`              | `"scroll"`      | No                      | When animation starts                                      |
+| `repeat`           | `boolean`                            | `true`          | No                      | Repeat entire animation                                    |
+| `initialDelay`     | `number`                             | `0`             | No                      | Initial delay before animation starts (in `s`)             |
+| `animationOrder`   | `"first-to-last" \| "last-to-first"` | `first-to-last` | No                      | Order of the animation sequence                            |
+| `motion`           | `Motion`                             | `-`             | Yes (if `preset` unset) | Custom animation config                                    |
+| `preset`           | `Preset[]`                           | `-`             | Yes (if `motion` unset) | Predefined animation presets                               |
+| `onAnimationStart` | `() => void`                         | `-`             | No                      | Callback function that is called when the animation starts |
+| `onAnimationEnd`   | `() => void`                         | `-`             | No                      | Callback function that is called when the animation ends   |
 
 <!-- > Full details: [API Docs](./docs/API.md) -->
 

--- a/src/components/AnimatedSpan/AnimatedSpan.spec.tsx
+++ b/src/components/AnimatedSpan/AnimatedSpan.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { AnimatedSpan } from './AnimatedSpan';
 
@@ -75,5 +75,18 @@ describe('AnimatedSpan component', () => {
 
     expect(span).toBeInTheDocument();
     expect(span?.style.animation).toBe('');
+  });
+
+  it('invokes onAnimationEnd callback only once', () => {
+    const onAnimationEndMock = jest.fn();
+    const { container } = render(<AnimatedSpan text={TEXT} style={STYLE} onAnimationEnd={onAnimationEndMock} />);
+    const span = container.querySelector('span');
+
+    if (span) {
+      fireEvent.animationEnd(span);
+      fireEvent.animationEnd(span);
+    }
+
+    expect(onAnimationEndMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/AnimatedSpan/AnimatedSpan.tsx
+++ b/src/components/AnimatedSpan/AnimatedSpan.tsx
@@ -1,10 +1,9 @@
-import { type FC } from 'react';
-
-import { type StyleWithCustomProperties } from '../../utils/generateAnimation/generateAnimation';
+import { type CSSProperties, type FC, useCallback, useRef } from 'react';
 
 type Props = {
   text: string;
-  style: StyleWithCustomProperties;
+  style: CSSProperties;
+  onAnimationEnd?: () => void;
 };
 
 /**
@@ -12,17 +11,27 @@ type Props = {
  * `AnimatedSpan` is a component that animates a text node by creating a `<span>` element with animation styles.
  *
  * @param {string} text - The text content to animate.
- * @param {StyleWithCustomProperties} style - The inline styles to apply to the `<span>` element.
+ * @param {CSSProperties} style - The inline styles to apply to the `<span>` element.
+ * @param {() => void} [onAnimationEnd] - Callback function that is called when the animation ends.
  *
  * @returns {JSX.Element} A React element `<span>` with inline animation styles.
  */
-export const AnimatedSpan: FC<Props> = ({ text, style }) => {
+export const AnimatedSpan: FC<Props> = ({ text, style, onAnimationEnd }) => {
+  const calledRef = useRef(false);
+
+  const handleAnimationEnd = useCallback(() => {
+    if (!calledRef.current) {
+      calledRef.current = true;
+      onAnimationEnd?.();
+    }
+  }, [onAnimationEnd]);
+
   if (text === '\n') {
     return <br />;
   }
 
   return (
-    <span style={style} aria-hidden="true">
+    <span style={style} aria-hidden="true" onAnimationEnd={handleAnimationEnd}>
       {text}
     </span>
   );

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -1,7 +1,7 @@
 import '../../styles/animations.scss';
 import '../../styles/motion.scss';
 
-import { type FC, memo } from 'react';
+import { type FC, memo, useEffect } from 'react';
 
 import { useAnimatedNode } from '../../hooks/useAnimatedNode';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
@@ -24,6 +24,7 @@ import { splitNodeAndExtractText } from '../../utils/splitNodeAndExtractText';
  * @param {'first-to-last' | 'last-to-first'} [animationOrder='first-to-last'] - Defines the order in which the animation sequence is applied. Defaults to `'first-to-last'`.
  * @param {Motion} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {Preset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
+ * @param {() => void} [onAnimationStart] - Callback function that is called when the animation starts.
  *
  * @returns {JSX.Element} A React element that renders animated children.
  *
@@ -41,6 +42,7 @@ import { splitNodeAndExtractText } from '../../utils/splitNodeAndExtractText';
  *         fade: { variant: 'in', duration: 0.25, delay: 0.025, easing: 'linear' },
  *         slide: { variant: 'up', duration: 0.25, delay: 0.025, easing: 'linear' },
  *       }}
+ *       onAnimationStart={() => console.log('Animation started')}
  *     >
  *       Hello <strong>World</strong>
  *     </NodeMotion>
@@ -57,6 +59,7 @@ import { splitNodeAndExtractText } from '../../utils/splitNodeAndExtractText';
  *       initialDelay={0.5}
  *       animationOrder="first-to-last"
  *       preset={['fade-in', 'slide-up']}
+ *       onAnimationStart={() => console.log('Animation started')}
  *     >
  *       <span>Hello</span> <b>World!</b>
  *     </NodeMotion>
@@ -74,12 +77,19 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
     animationOrder = 'first-to-last',
     motion,
     preset,
+    onAnimationStart,
   } = props;
 
   useValidation('NodeMotion', props);
 
   const [targetRef, isIntersecting] = useIntersectionObserver<HTMLSpanElement>({ repeat });
   const shouldAnimate = trigger === 'on-load' || isIntersecting;
+
+  useEffect(() => {
+    if (shouldAnimate) {
+      onAnimationStart?.();
+    }
+  }, [shouldAnimate, onAnimationStart]);
 
   const { splittedNode, text } = splitNodeAndExtractText(children, split);
 

--- a/src/components/NodeMotion/NodeMotion.tsx
+++ b/src/components/NodeMotion/NodeMotion.tsx
@@ -25,6 +25,7 @@ import { splitNodeAndExtractText } from '../../utils/splitNodeAndExtractText';
  * @param {Motion} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {Preset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  * @param {() => void} [onAnimationStart] - Callback function that is called when the animation starts.
+ * @param {() => void} [onAnimationEnd] - Callback function that is called when the animation ends.
  *
  * @returns {JSX.Element} A React element that renders animated children.
  *
@@ -43,6 +44,7 @@ import { splitNodeAndExtractText } from '../../utils/splitNodeAndExtractText';
  *         slide: { variant: 'up', duration: 0.25, delay: 0.025, easing: 'linear' },
  *       }}
  *       onAnimationStart={() => console.log('Animation started')}
+ *       onAnimationEnd={() => console.log('Animation ended')}
  *     >
  *       Hello <strong>World</strong>
  *     </NodeMotion>
@@ -60,6 +62,7 @@ import { splitNodeAndExtractText } from '../../utils/splitNodeAndExtractText';
  *       animationOrder="first-to-last"
  *       preset={['fade-in', 'slide-up']}
  *       onAnimationStart={() => console.log('Animation started')}
+ *       onAnimationEnd={() => console.log('Animation ended')}
  *     >
  *       <span>Hello</span> <b>World!</b>
  *     </NodeMotion>
@@ -78,6 +81,7 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
     motion,
     preset,
     onAnimationStart,
+    onAnimationEnd,
   } = props;
 
   useValidation('NodeMotion', props);
@@ -94,7 +98,7 @@ export const NodeMotion: FC<NodeMotionProps> = memo(props => {
   const { splittedNode, text } = splitNodeAndExtractText(children, split);
 
   const resolvedMotion = useResolvedMotion(motion, preset);
-  const animatedNode = useAnimatedNode(splittedNode, initialDelay, animationOrder, resolvedMotion);
+  const animatedNode = useAnimatedNode(splittedNode, initialDelay, animationOrder, resolvedMotion, onAnimationEnd);
 
   return (
     <Tag ref={targetRef} className="node-motion" aria-label={text}>

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -1,7 +1,7 @@
 import '../../styles/animations.scss';
 import '../../styles/motion.scss';
 
-import { type FC, memo } from 'react';
+import { type FC, memo, useEffect } from 'react';
 
 import { AnimatedSpan } from '../../components/AnimatedSpan';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
@@ -26,6 +26,7 @@ import { splitText } from '../../utils/splitText';
  * @param {'first-to-last' | 'last-to-first'} [animationOrder='first-to-last'] - Defines the order in which the animation sequence is applied. Defaults to `'first-to-last'`.
  * @param {Motion} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {Preset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
+ * @param {() => void} [onAnimationStart] - Callback function that is called when the animation starts.
  *
  * @returns {JSX.Element} A React element that renders animated `<span>`s for each split unit of text.
  *
@@ -44,6 +45,7 @@ import { splitText } from '../../utils/splitText';
  *         fade: { variant: 'in', duration: 0.25, delay: 0.025, easing: 'linear' },
  *         slide: { variant: 'up', duration: 0.25, delay: 0.025, easing: 'linear' },
  *       }}
+ *       onAnimationStart={() => console.log('Animation started')}
  *     />
  *   );
  * }
@@ -59,6 +61,7 @@ import { splitText } from '../../utils/splitText';
  *       initialDelay={0.5}
  *       animationOrder="first-to-last"
  *       preset={['fade-in', 'slide-up']}
+ *       onAnimationStart={() => console.log('Animation started')}
  *     />
  *   );
  * }
@@ -74,6 +77,7 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
     animationOrder = 'first-to-last',
     motion,
     preset,
+    onAnimationStart,
   } = props;
 
   useValidation('TextMotion', props);
@@ -81,8 +85,13 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
   const [targetRef, isIntersecting] = useIntersectionObserver<HTMLSpanElement>({ repeat });
   const shouldAnimate = trigger === 'on-load' || isIntersecting;
 
-  const splittedText = splitText(text, split);
+  useEffect(() => {
+    if (shouldAnimate) {
+      onAnimationStart?.();
+    }
+  }, [shouldAnimate, onAnimationStart]);
 
+  const splittedText = splitText(text, split);
   const resolvedMotion = useResolvedMotion(motion, preset);
 
   const animatedNode = splittedText.map((text, index) => {

--- a/src/components/TextMotion/TextMotion.tsx
+++ b/src/components/TextMotion/TextMotion.tsx
@@ -27,6 +27,7 @@ import { splitText } from '../../utils/splitText';
  * @param {Motion} [motion] - Custom motion configuration object. Cannot be used with `preset`.
  * @param {Preset[]} [preset] - Predefined motion presets. Cannot be used with `motion`.
  * @param {() => void} [onAnimationStart] - Callback function that is called when the animation starts.
+ * @param {() => void} [onAnimationEnd] - Callback function that is called when the animation ends.
  *
  * @returns {JSX.Element} A React element that renders animated `<span>`s for each split unit of text.
  *
@@ -46,6 +47,7 @@ import { splitText } from '../../utils/splitText';
  *         slide: { variant: 'up', duration: 0.25, delay: 0.025, easing: 'linear' },
  *       }}
  *       onAnimationStart={() => console.log('Animation started')}
+ *       onAnimationEnd={() => console.log('Animation ended')}
  *     />
  *   );
  * }
@@ -62,6 +64,7 @@ import { splitText } from '../../utils/splitText';
  *       animationOrder="first-to-last"
  *       preset={['fade-in', 'slide-up']}
  *       onAnimationStart={() => console.log('Animation started')}
+ *       onAnimationEnd={() => console.log('Animation ended')}
  *     />
  *   );
  * }
@@ -78,6 +81,7 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
     motion,
     preset,
     onAnimationStart,
+    onAnimationEnd,
   } = props;
 
   useValidation('TextMotion', props);
@@ -94,11 +98,14 @@ export const TextMotion: FC<TextMotionProps> = memo(props => {
   const splittedText = splitText(text, split);
   const resolvedMotion = useResolvedMotion(motion, preset);
 
+  const lastIndex = animationOrder === 'first-to-last' ? splittedText.length - 1 : 0;
   const animatedNode = splittedText.map((text, index) => {
     const sequenceIndex = animationOrder === 'first-to-last' ? index : splittedText.length - (index + 1);
     const { style } = generateAnimation(resolvedMotion, sequenceIndex, initialDelay);
 
-    return <AnimatedSpan key={index} text={text} style={style} />;
+    const handleAnimationEnd = index === lastIndex ? onAnimationEnd : undefined;
+
+    return <AnimatedSpan key={index} text={text} style={style} onAnimationEnd={handleAnimationEnd} />;
   });
 
   return (

--- a/src/hooks/useValidation/validation.spec.ts
+++ b/src/hooks/useValidation/validation.spec.ts
@@ -28,6 +28,9 @@ describe('validation utility', () => {
         repeat: 'yes' as any,
         initialDelay: -5,
         animationOrder: 'reverse' as any,
+        preset: 'fade-in' as any,
+        onAnimationStart: 'Animation Start' as any,
+        onAnimationEnd: 'Animation End' as any,
       };
       const { errors } = validateTextMotionProps(props);
 
@@ -37,6 +40,9 @@ describe('validation utility', () => {
         'repeat prop must be a boolean',
         'initialDelay prop must be non-negative',
         'animationOrder prop must be one of: first-to-last, last-to-first',
+        'preset prop must be an array',
+        'onAnimationStart prop must be a function',
+        'onAnimationEnd prop must be a function',
       ]);
     });
 

--- a/src/hooks/useValidation/validation.ts
+++ b/src/hooks/useValidation/validation.ts
@@ -97,6 +97,18 @@ const validateCommonProps = (props: Partial<TextMotionProps | NodeMotionProps>):
     warnings.push(...motionValidation.warnings);
   }
 
+  if (props.preset !== undefined && !Array.isArray(props.preset)) {
+    errors.push('preset prop must be an array');
+  }
+
+  if (props.onAnimationStart !== undefined && typeof props.onAnimationStart !== 'function') {
+    errors.push('onAnimationStart prop must be a function');
+  }
+
+  if (props.onAnimationEnd !== undefined && typeof props.onAnimationEnd !== 'function') {
+    errors.push('onAnimationEnd prop must be a function');
+  }
+
   return { errors, warnings };
 };
 

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -10,6 +10,7 @@ export type BaseMotionProps = {
   initialDelay?: number;
   animationOrder?: AnimationOrder;
   onAnimationStart?: () => void;
+  onAnimationEnd?: () => void;
 };
 
 export type MotionPresetProps =

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -9,6 +9,7 @@ export type BaseMotionProps = {
   repeat?: boolean;
   initialDelay?: number;
   animationOrder?: AnimationOrder;
+  onAnimationStart?: () => void;
 };
 
 export type MotionPresetProps =


### PR DESCRIPTION
## Description

Added `onAnimationStart` and `onAnimationEnd` callback props to `TextMotion` and `NodeMotion` components.  
These props allow external functions to be executed at the start and end of the animation, enabling more flexible side effects such as event tracking, state updates, or triggering subsequent animations.

## Related Issue

Closes #58 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] My code follows the project style guidelines
- [x] I performed a self-review of my own code
- [x] I added tests that prove my fix is effective
- [x] I added necessary documentation